### PR TITLE
Resourcely remediation proposal for config root: basic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,8 @@ resource "aws_db_instance" "example-rds_TJXZTFi3qSy724Fv" {
   username                     = "db_user"
   password                     = "password"
   backup_retention_period      = 7
-  storage_encrypted            = false
+  storage_encrypted            = true
+  kms_key_is                   = aws_kms_key.kmskey_6rqH9awtV732LCTF.arn
   multi_az                     = true
   deletion_protection          = true
   performance_insights_enabled = true

--- a/resourcely.tf
+++ b/resourcely.tf
@@ -14,10 +14,13 @@ resource "terraform_data" "resourcely_context_answers" {
           "resource.aws_kms_key.kmskey_YQxK9CH3weQj5E7Y",
           "resource.aws_db_instance.example-rds_YDW8SL8PdmHMCwDu",
           "resource.aws_kms_key.kmskey_6rqH9awtV732LCTF",
-          "resource.aws_db_instance.example-rds_kB9bGDNyJmy9WPbv",
-          "resource.aws_db_instance.example-rds_TJXZTFi3qSy724Fv"
+          "resource.aws_db_instance.example-rds_kB9bGDNyJmy9WPbv"
         ],
         "gdpr_apply" : "Yes"
+      },
+      {
+        "$applies_to" : "resource.aws_db_instance.example-rds_TJXZTFi3qSy724Fv",
+        "gdpr_apply" : "No"
       }
     ]
   }


### PR DESCRIPTION
Fixing RDS issues
Note: we recommend not adding commits to this outside of the web UI to avoid unexpected behavior.

## Requested approvals by resource
These are preexisting violations for which the remediator is requesting approvals, grouped by the resource in violation.
### aws_db_instance.example-rds_TJXZTFi3qSy724Fv:
Guardrail: Disallow performance insights
Category: Cost Efficiency
Requirement: REQUIRE performance_insights_enabled = false
Contact: csreuter
Request notes: Need performance insights for this t1 application
